### PR TITLE
Use shorter Pipeline symbol

### DIFF
--- a/src/main/java/io/jenkins/plugins/zerobug/ZeroBugPublisher.java
+++ b/src/main/java/io/jenkins/plugins/zerobug/ZeroBugPublisher.java
@@ -133,7 +133,7 @@ public class ZeroBugPublisher extends Recorder implements SimpleBuildStep {
 		}
 	}
 
-	@Symbol("ZeroBugPublisher")
+	@Symbol("zeroBug", "ZeroBugPublisher") // Prefer zeroBug, accept ZeroBugPublisher as Pipeline keyword
 	@Extension
 	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 

--- a/src/main/java/io/jenkins/plugins/zerobug/ZeroBugPublisher.java
+++ b/src/main/java/io/jenkins/plugins/zerobug/ZeroBugPublisher.java
@@ -133,7 +133,8 @@ public class ZeroBugPublisher extends Recorder implements SimpleBuildStep {
 		}
 	}
 
-	@Symbol("zeroBug", "ZeroBugPublisher") // Prefer zeroBug, accept ZeroBugPublisher as Pipeline keyword
+	@Symbol({"zeroBug", "ZeroBugPublisher"}) // Prefer zeroBug, accept ZeroBugPublisher as keyword
+
 	@Extension
 	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 

--- a/src/main/java/io/jenkins/plugins/zerobug/ZeroBugPublisher.java
+++ b/src/main/java/io/jenkins/plugins/zerobug/ZeroBugPublisher.java
@@ -134,7 +134,6 @@ public class ZeroBugPublisher extends Recorder implements SimpleBuildStep {
 	}
 
 	@Symbol({"zeroBug", "ZeroBugPublisher"}) // Prefer zeroBug, accept ZeroBugPublisher as keyword
-
 	@Extension
 	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 


### PR DESCRIPTION
## Use Pipeline symbol that matches symbol naming convention

The Pipeline symbol naming convention advises a leading lower case letter with camel case.  This pull request retains the previous symbol for compatibility and adds a preferred symbol with a leading lower case letter and without the "Publisher" suffix.